### PR TITLE
Refactor class extraction

### DIFF
--- a/lib/masamune-ast/abstract_syntax_tree/params.rb
+++ b/lib/masamune-ast/abstract_syntax_tree/params.rb
@@ -8,8 +8,14 @@ module Masamune
       end
 
       def extract_data_nodes
-        @contents[1].map do |content|
-          Masamune::AbstractSyntaxTree::DataNode.new(content, @ast_id)
+        # TODO: Sometimes the params node looks like this:
+        # [:params, nil, nil, nil, nil, nil, nil, nil]
+        # Add a description for this, and review this portion
+        # to ensure that it's being handled properly.
+        unless @contents[1].nil?
+          @contents[1].map do |content|
+            Masamune::AbstractSyntaxTree::DataNode.new(content, @ast_id)
+          end
         end
       end
     end


### PR DESCRIPTION
```ruby
x = 1
```

The output from `Ripper.sexp` for this code:
```ruby
[:program,
  [
    [:assign,
      [:var_field, [:@ident, "x", [1, 0]]],
      [:@int, "1", [1, 4]]
    ]
  ]
]
```

Since nodes start with a type (a Symbol that represents what operation the node is performing), I wanted to expose that layer of abstraction explicitly in the code instead of just writing what I had before when grabbing the appropriate node class:

```ruby
class_name = "Masamune::AbstractSyntaxTree::#{tree_node.first.to_s.camelize}"
klass = class_name.constantize
msmn_node = klass.new(tree_node, self.__id__)
```

For whoever's reading the code, this doesn't explicitly say what `tree_node.first` is, but with this new patch we show them that the type is originally defined as a symbol, we show them that this value represents a `type` as can be seen in the argument for the `get_node_class` method, and we find the class via that symbol. I think this will make the code easier to read, especially if developers want to check their results against `Ripper.sexp`'s output itself.
