### PR TITLE
Add the sorting method for position and token arrays

### DIFF
--- a/lib/masamune-ast/abstract_syntax_tree/data_node.rb
+++ b/lib/masamune-ast/abstract_syntax_tree/data_node.rb
@@ -3,6 +3,14 @@
 # These values are the `type`, `token`, and `position`, respectively.
 # It is simliar to what you see in `Ripper.lex(code)` and `Masamune::AbstractSyntaxTree's @lex_nodes`.
 
+# We break this down into a simpler structure, `position_and_token`,
+# which looks like this: [[4, 7], "ruby"]
+# TODO: I eventually want to change this to the following:
+# [
+#   {position: [4, 7], token: "ruby"},
+#   {position: [1, 2], token: "rails"}
+# ]
+
 module Masamune
   class AbstractSyntaxTree
     class DataNode < Node
@@ -13,15 +21,42 @@ module Masamune
         super(contents, ast_id)
       end
 
-      def position_and_token
-        [@line_position, @token]
-      end
-
-      # TODO: Write this method.
       # Results here represent the data we get when searching for data.
       # For example, [[[4, 7], "ruby"], [[7, 7], "rails"]].
+      # TODO: Worry about using a faster sorting algorithm later.
       def self.order_results_by_position(position_and_token_ary)
-        position_and_token_ary
+        line_numbers = position_and_token_ary.map do |position_and_token|
+          position = position_and_token.first
+          line_number = position.first
+          line_number
+        end.uniq.sort
+
+        final_result = []
+        line_numbers.each do |line_number|
+          # Group data together in an array if they're on the same line.
+          shared_line_data = position_and_token_ary.select do |position_and_token|
+            position = position_and_token.first
+            position.first == line_number
+          end
+
+          # Sort the positions on each line number respectively.
+          positions_on_line = shared_line_data.map do |data|
+            data.first.last
+          end.sort
+
+          # Apply to the final result.
+          positions_on_line.each do |position|
+            shared_line_data.each do |data|
+              final_result << data if data.first.last == position
+            end
+          end
+        end
+
+        final_result
+      end
+
+      def position_and_token
+        [@line_position, @token]
       end
     end
   end


### PR DESCRIPTION
```ruby
[1, 2].sum.times {|n| puts n}
```

This code produces the following syntax tree with Ripper:
```ruby
[:program,
 [[:method_add_block,
   [:call,
    [:call, [:array, [[:@int, "1", [1, 1]], [:@int, "2", [1, 4]]]], [:@period, ".", [1, 6]], [:@ident, "sum", [1, 7]]],
    [:@period, ".", [1, 10]],
    [:@ident, "times", [1, 11]]],
   [:brace_block,
    [:block_var, [:params, [[:@ident, "n", [1, 19]]], nil, nil, nil, nil, nil, nil], false],
    [[:command, [:@ident, "puts", [1, 22]], [:args_add_block, [[:var_ref, [:@ident, "n", [1, 27]]]], false]]]]]]]
```

You can see that a `:call` node is nested within the first `:call` node. Because each `:call` node's data node is the last element within it, we grab that element and save it to the list of data nodes first. THEN we go inside the nested call recursively and get all the remaining information. So, for example...

```ruby
p msmn.data[1][0][1]

[:call,
 # ↓ We search this second call node later
 [:call, [:array, [[:@int, "1", [1, 1]], [:@int, "2", [1, 4]]]], [:@period, ".", [1, 6]], [:@ident, "sum", [1, 7]]],
 [:@period, ".", [1, 10]],
 # ↓ This is the initial data node we extract since
 # we're in the first :call node we came across in the AST.
 [:@ident, "times", [1, 11]]]
```

Then when we get to the nested `:call`...
```ruby
msmn2.data[1][0][1][1]

[:call,
  [:array, [[:@int, "1", [1, 1]], [:@int, "2", [1, 4]]]],
  [:@period, ".", [1, 6]],
  [:@ident, "sum", [1, 7]] # Then we grab this data node
]
```

This means the data nodes are reversed when getting the positions and tokens:
```ruby
msmn = Masamune::AbstractSyntaxTree.new("[1, 2].sum.times {|n| puts n}")
msmn.all_methods
#=> [[[1, 11], "times"], [[1, 7], "sum"]]
```

This PR ensures we sort the line positions and return them in the correct order

```ruby
#=> [[[1, 7], "sum"], [[1, 11], "times"]]
```

## Why I opted not to create each data node recursively to then register them to the data node list
I want to parse the tree and assign classes to each node linearly to keep it inline with the structure of the original abstract syntax tree. That means I assign each node as is as it shows up in the AST, and I don't want to have to worry about sorting the nodes themselves according to the line number, etc.

In that way we can let the AST just be what it is, and after we've created all the node class instances, we can perform any sorting on data we extract from it to keep those parts of the logic separate.