### PR TITLE
Define position and token data as Hashes

### DIFF
--- a/test/test_masamune.rb
+++ b/test/test_masamune.rb
@@ -65,7 +65,7 @@ class TestMasamune< Minitest::Test
     methods = msmn.all_methods
     assert methods.size == 5
 
-    method_names = methods.map {|m| m.last}
+    method_names = methods.map {|m| m[:token]}
     assert method_names.include?("sum")
     assert method_names.include?("times")
 
@@ -74,8 +74,8 @@ class TestMasamune< Minitest::Test
 
     # Check block params and their line positions.
     assert msmn.block_params.size == 4
-    assert msmn.block_params.first == [[4, 18], "n"]
-    assert msmn.block_params.last == [[11, 23], "v"]
+    assert msmn.block_params.first == {position: [4, 18], token: "n"}
+    assert msmn.block_params.last == {position: [11, 23], token: "v"}
   end
 
   def test_lex_nodes_return_proper_type


### PR DESCRIPTION
Before, running `Masamune::AbstractSyntaxTree.new("x = 1").variables` would return this:
```ruby
[[[1, 0], "x"]]
```

This isn't very descriptive, so I decided to change this to the following:
```ruby
[{position: [1, 0], token: "x"}]
```

Since it's a hash inside an array it's easier to look it, and it should be easier to read since each piece of data has a key attached to it.

## Why I'm not returning `Masamune::AbstractSyntaxTree::DataNode` objects
I want to add an option to return `Masamune::AbstractSyntaxTree::DataNode` objects when performing a search like `msmn.variables`, but since these objects tend to have a lot of information, I thought it would be beneficial to just return a list of hashes. I have made a note [here](https://github.com/gazayas/masamune-ast/blob/1b28808248af72bd0b4e0c15047a2c6c778e2691/lib/masamune/abstract_syntax_tree.rb#L81) to implement this though in case we want it in the future.