### PR TITLE
Add support nodes

### DIFF
--- a/lib/masamune.rb
+++ b/lib/masamune.rb
@@ -11,6 +11,7 @@ require "masamune/abstract_syntax_tree/data_node"
 
 require "masamune/abstract_syntax_tree/nodes/blocks/brace_block"
 require "masamune/abstract_syntax_tree/nodes/blocks/do_block"
+require "masamune/abstract_syntax_tree/nodes/support_nodes/comment"
 require "masamune/abstract_syntax_tree/nodes/symbols/dyna_symbol"
 require "masamune/abstract_syntax_tree/nodes/symbols/symbol_literal"
 require "masamune/abstract_syntax_tree/nodes/variables/block_var"

--- a/lib/masamune.rb
+++ b/lib/masamune.rb
@@ -9,9 +9,11 @@ require "masamune/abstract_syntax_tree"
 require "masamune/abstract_syntax_tree/node"
 require "masamune/abstract_syntax_tree/data_node"
 
+require "masamune/abstract_syntax_tree/nodes/support_nodes/block"
+require "masamune/abstract_syntax_tree/nodes/support_nodes/comment"
+
 require "masamune/abstract_syntax_tree/nodes/blocks/brace_block"
 require "masamune/abstract_syntax_tree/nodes/blocks/do_block"
-require "masamune/abstract_syntax_tree/nodes/support_nodes/comment"
 require "masamune/abstract_syntax_tree/nodes/symbols/dyna_symbol"
 require "masamune/abstract_syntax_tree/nodes/symbols/symbol_literal"
 require "masamune/abstract_syntax_tree/nodes/variables/block_var"

--- a/lib/masamune/abstract_syntax_tree/nodes/blocks/brace_block.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/blocks/brace_block.rb
@@ -2,17 +2,11 @@
 
 module Masamune
   class AbstractSyntaxTree
-    class BraceBlock < Node
+    class BraceBlock < Block
       attr_accessor :ast_id
 
       def initialize(contents, ast_id)
         super
-      end
-
-      def params
-        # This node should exist already, so we search for it in the ast object.
-        block_var = BlockVar.new(contents[1], ast_id)
-        ast.node_list.find {|node| node.contents == block_var.contents}
       end
     end
   end

--- a/lib/masamune/abstract_syntax_tree/nodes/blocks/do_block.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/blocks/do_block.rb
@@ -2,17 +2,11 @@
 
 module Masamune
   class AbstractSyntaxTree
-    class DoBlock < Node
+    class DoBlock < Block
       attr_accessor :ast_id
 
       def initialize(contents, ast_id)
         super
-      end
-
-      def params
-        # This node should exist already, so we search for it in the ast object.
-        block_var = BlockVar.new(contents[1], ast_id)
-        ast.node_list.find {|node| node.contents == block_var.contents}
       end
     end
   end

--- a/lib/masamune/abstract_syntax_tree/nodes/support_nodes/block.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/support_nodes/block.rb
@@ -1,0 +1,18 @@
+# DoBlock and BraceBlock share some of
+# the same logic, so we share that here.
+
+module Masamune
+  class AbstractSyntaxTree
+    class Block < Node
+      def initialize(contents, ast_id)
+        super
+      end
+
+      def params
+        # This node should exist already, so we search for it in the ast object.
+        block_var = BlockVar.new(contents[1], ast_id)
+        ast.node_list.find {|node| node.contents == block_var.contents}
+      end
+    end
+  end
+end

--- a/lib/masamune/abstract_syntax_tree/nodes/support_nodes/comment.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/support_nodes/comment.rb
@@ -1,0 +1,24 @@
+# In the abstract syntax tree created by Ripper.sexp,
+# the type for comments is :void_stmt, and it doesn't have
+# a data node within it either. This means that the text
+# for the comment doesn't exist in the ast. It DOES exist
+# in LexNode though, so we grab from them there instead.
+
+module Masamune
+  class AbstractSyntaxTree
+    class Comment < Node
+      def initialize(contents, ast_id)
+        # Since this is techincally supposed to be a :void_stmt
+        # in this ast, we just leave this as nil.
+        @contents = nil
+        super
+      end
+
+      def extract_data_nodes
+        [
+          DataNode.new([contents.type, contents.token, contents.position], @ast_id)
+        ]
+      end
+    end
+  end
+end

--- a/lib/masamune/abstract_syntax_tree/nodes/support_nodes/comment.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/support_nodes/comment.rb
@@ -8,10 +8,11 @@ module Masamune
   class AbstractSyntaxTree
     class Comment < Node
       def initialize(contents, ast_id)
+        super
+
         # Since this is techincally supposed to be a :void_stmt
         # in this ast, we just leave this as nil.
         @contents = nil
-        super
       end
 
       def extract_data_nodes


### PR DESCRIPTION
There is no type `:comment` in the AST from Ripper.sexp, so we pull that data from LexNode instead.

For that reason, I've decided to add `@comment_list` as opposed to adding `Masamune::AbstractSyntaxTree::Comment` objects to `@data_node_list`. It technically already exists as `:void_stmt` types, so I don't want to double up the objects in the list.