### PR TITLE
Add parent attribute to DataNode

### DIFF
--- a/lib/masamune/abstract_syntax_tree/data_node.rb
+++ b/lib/masamune/abstract_syntax_tree/data_node.rb
@@ -11,8 +11,9 @@ module Masamune
     class DataNode < Node
       attr_reader :type, :token, :line_position
 
-      def initialize(contents, ast_id)
+      def initialize(contents, ast_id, parent)
         @type, @token, @line_position = contents
+        @parent = parent
         super(contents, ast_id)
       end
 

--- a/lib/masamune/abstract_syntax_tree/nodes/call.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/call.rb
@@ -9,7 +9,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents.last, @ast_id)
+          DataNode.new(@contents.last, @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/def.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/def.rb
@@ -9,7 +9,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents[1], @ast_id)
+          DataNode.new(@contents[1], @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/params.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/params.rb
@@ -14,7 +14,7 @@ module Masamune
         # to ensure that it's being handled properly.
         unless @contents[1].nil?
           @contents[1].map do |content|
-            DataNode.new(content, @ast_id)
+            DataNode.new(content, @ast_id, self)
           end
         end
       end

--- a/lib/masamune/abstract_syntax_tree/nodes/string_content.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/string_content.rb
@@ -9,7 +9,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents[1], @ast_id)
+          DataNode.new(@contents[1], @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/support_nodes/comment.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/support_nodes/comment.rb
@@ -17,7 +17,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new([contents.type, contents.token, contents.position], @ast_id)
+          DataNode.new([contents.type, contents.token, contents.position], @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/symbol.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/symbol.rb
@@ -9,7 +9,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents[1], @ast_id)
+          DataNode.new(@contents[1], @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/symbols/dyna_symbol.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/symbols/dyna_symbol.rb
@@ -13,7 +13,7 @@ module Masamune
       # we just use a method specifically for getting the symbol.
       # This should be the same as the :symbol_literal type.
       def get_symbol_data
-        DataNode.new(@contents[1][1], @ast_id)
+        DataNode.new(@contents[1][1], @ast_id, self)
       end
     end
   end

--- a/lib/masamune/abstract_syntax_tree/nodes/symbols/symbol_literal.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/symbols/symbol_literal.rb
@@ -14,7 +14,7 @@ module Masamune
       # we just use a method specifically for getting the symbol.
       # This should be the same as the :dyna_symbol type.
       def get_symbol_data
-        DataNode.new(@contents[1][1], @ast_id)
+        DataNode.new(@contents[1][1], @ast_id, self)
       end
     end
   end

--- a/lib/masamune/abstract_syntax_tree/nodes/variables/block_var.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/variables/block_var.rb
@@ -14,7 +14,7 @@ module Masamune
       # nice to find out and document/implement it somewhere.
       def extract_data_nodes
         @contents[1][1].map do |content|
-          DataNode.new(content, @ast_id)
+          DataNode.new(content, @ast_id, self)
         end
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/variables/var_field.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/variables/var_field.rb
@@ -9,7 +9,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents[1], @ast_id)
+          DataNode.new(@contents[1], @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/variables/var_ref.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/variables/var_ref.rb
@@ -11,7 +11,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents[1], @ast_id)
+          DataNode.new(@contents[1], @ast_id, self)
         ]
       end
     end

--- a/lib/masamune/abstract_syntax_tree/nodes/vcall.rb
+++ b/lib/masamune/abstract_syntax_tree/nodes/vcall.rb
@@ -9,7 +9,7 @@ module Masamune
 
       def extract_data_nodes
         [
-          DataNode.new(@contents[1], @ast_id)
+          DataNode.new(@contents[1], @ast_id, self)
         ]
       end
     end


### PR DESCRIPTION
When a node has a data node, it is added as an attribute upon initialization so we can access data nodes as an attribute:

https://github.com/gazayas/masamune-ast/blob/dc3fefaf4fb7d91cc4c2e068b9a1b26471216694/lib/masamune/abstract_syntax_tree/node.rb#L11

However, there's no way of knowing the parent if we're looking simply at the data node itself.

This pull request enables us to get the parent as well if needed.