### PR TITLE
Move pry require to tests

### DIFF
--- a/lib/masamune.rb
+++ b/lib/masamune.rb
@@ -30,7 +30,6 @@ require "masamune/abstract_syntax_tree/nodes/symbol"
 require "masamune/abstract_syntax_tree/nodes/vcall"
 
 require "pp"
-require "pry"
 
 module Masamune
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,4 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "masamune"
 
 require "minitest/autorun"
+require "pry"


### PR DESCRIPTION
While I was working on https://github.com/bullet-train-co/bullet_train-core/pull/597, I found that I had to add:

```ruby
gem "masamune-ast" # TODO: Remove the bullet_train.gemspec dependency to super_scaffolding's gemspec.
gem "pry" # TODO: Remove masumune's internal `require "pry"` call.
```

Ref: https://github.com/bullet-train-co/bullet_train-core/pull/597/files#diff-68cca28f9c2368a9481c0ade06f7da3d4c5c13dd81597e53201ece7c00c8fa90R14-R15

Where masamune expected client apps to have `pry` included in their Gemfiles, which everyone might not.

Since pry is mostly a dev-dependency, I've moved the require to the test_helper.rb