### PR TITLE
For 2.0: Bump minimum Ruby version to 2.7.0

### DIFF
--- a/masamune-ast.gemspec
+++ b/masamune-ast.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A layer of abstraction on top of Ripper for handling Abstract Syntax Trees in Ruby."
   spec.homepage = "https://www.github.com/gazayas/masamune-ast"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 


### PR DESCRIPTION
Ruby 2.6 is long since out of maintenance so I think we should bump the minimum version for 2.0.

There's still a big Bullet Train app on 2.7, so we can't just push this to 3.0 yet.

We can just have this PR open until just before 2.0 and then merge, so it makes any needed 1.x releases easier.