### PR TITLE
Fix results for the call node visitor

### DIFF
--- a/lib/masamune/abstract_syntax_tree/visitors/method_calls_visitor.rb
+++ b/lib/masamune/abstract_syntax_tree/visitors/method_calls_visitor.rb
@@ -10,7 +10,7 @@ module Masamune
 
       def visit_call_node(node)
         if node.method_call?
-          results << node if token_value.nil? || token_value == node.name
+          results << node if token_value.nil? || token_value == node.name.to_s
         end
         super
       end

--- a/lib/masamune/abstract_syntax_tree/visitors/method_calls_visitor.rb
+++ b/lib/masamune/abstract_syntax_tree/visitors/method_calls_visitor.rb
@@ -9,6 +9,7 @@ module Masamune
       end
 
       def visit_call_node(node)
+        # TODO: We should probably replace this with unless node.variable_call?
         if node.method_call?
           results << node if token_value.nil? || token_value == node.name.to_s
         end


### PR DESCRIPTION
Methods like `times` return a string for `CallNode`s, but when using this against `namespace` in a routes file, it returned a symbol instead, so the node wasn't getting registered to the results.